### PR TITLE
Fix #18

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,1 +1,4 @@
+import * as defaultParsers from "./parsers.ts";
+
 export { marky } from "./marky.ts";
+export { defaultParsers };


### PR DESCRIPTION
Export { defaultParsers } so they can be used as demonstrated in readme.md

This is needed for marky to work correctly when imported from deno.land/x/marky

Fixes issue https://github.com/askonomm/marky/issues/18